### PR TITLE
Fix deprecation warnings in Elevator and Zoning classes

### DIFF
--- a/src/Elevator.java
+++ b/src/Elevator.java
@@ -195,7 +195,9 @@ public class Elevator {
             @Override
             public void run() {
 
-                int Z = new Double(Math.ceil((double) getN() / getL())).intValue();
+                // int Z = new Double(Math.ceil((double) getN() / getL())).intValue();
+                int Z = Double.valueOf(Math.ceil((double) getN() / getL())).intValue();
+
 
                 while (true){
 

--- a/src/Zoning.java
+++ b/src/Zoning.java
@@ -15,8 +15,12 @@ public class Zoning {
      */
     public int choseElevator(int L, int N, int floor){
 
-        int Z = new Double(Math.ceil((double) N / L)).intValue(); // Z is the number of zones
+        // int Z = new Double(Math.ceil((double) N / L)).intValue(); // Z is the number of zones
+        int Z = Double.valueOf(Math.ceil((double) N / L)).intValue(); // Z is the number of zones
 
-        return (new Double(Math.floor((double) floor / Z)).intValue());
+
+        // return (new Double(Math.floor((double) floor / Z)).intValue());
+        return Double.valueOf(Math.floor((double) floor / Z)).intValue();
+
     }
 }


### PR DESCRIPTION
Hello,

While compiling the code in JDK 21, I found warnings related to the deprecation of the Double(double) constructor in the Double class, which has been flagged for removal in future versions.
